### PR TITLE
[WIP] Include current wit-bindgen configuration

### DIFF
--- a/bindings/.gitignore
+++ b/bindings/.gitignore
@@ -1,0 +1,2 @@
+bindings
+

--- a/bindings/Dockerfile
+++ b/bindings/Dockerfile
@@ -1,0 +1,36 @@
+# Download and build a compatible version wit-bindgen
+# Originally from:
+# https://github.com/ospencer/witx-bindgen/tree/oscar/js-buffer-size
+FROM rust:slim-bullseye AS tooling
+
+RUN apt update && apt install -y git 
+
+WORKDIR /tmp
+
+RUN mkdir witx-bindgen && \
+    git clone https://github.com/bytecodealliance/wit-bindgen.git --single-branch wit-bindgen && \
+    cd wit-bindgen && \
+    git checkout 48f364d1d4e42275b219d0862af8aa8b17c49d51 && \
+    cargo build --release
+
+# Executable in /tmp/wit-bindgen/target/release/wit-bindgen
+
+
+FROM rust:slim-bullseye AS sdk
+
+#RUN mkdir wit-bindgen && \
+#    git clone https://github.com/suborbital/sdk.git --single-branch --branch v0.16.3 && \
+#    cd wit-bindgen && \
+
+WORKDIR /tmp
+
+COPY --from=tooling /tmp/wit-bindgen/target/release/wit-bindgen /usr/bin/
+COPY env.wit .
+
+# Generate JS & TS bindings
+RUN wit-bindgen js --import env.wit
+
+# Generate Rust bindings
+RUN wit-bindgen rust-wasm --import env.wit
+
+CMD wit-bindgen --help

--- a/bindings/bindings.sh
+++ b/bindings/bindings.sh
@@ -1,0 +1,8 @@
+# Build and test
+docker build . -t se2-sdk-bindings
+docker run -t se2-sdk-bindings ls -a /tmp
+
+# Extract the built files
+id=$(docker create se2-sdk-bindings:latest)
+docker cp $id:/tmp ./bindings
+docker rm -v $id

--- a/bindings/env.wit
+++ b/bindings/env.wit
@@ -1,0 +1,36 @@
+enum log-level {
+    null,
+    error,
+    warn,
+    info,
+    debug
+}
+enum http-method {
+    get,
+    head,
+    options,
+    post,
+    put,
+    patch,
+    delete
+}
+enum field-type {
+    meta,
+    body,
+    header,
+    params,
+    state,
+    query
+}
+
+return-result: function(res: list<u8>, ident: u32)
+return-error: function(code: s32, res: string, ident: u32)
+log-msg: function(msg: string, level: log-level, ident: u32)
+fetch-url: function(method: http-method, url: string, body: list<u8>, ident: u32) -> s32
+graphql-query: function(endpoint: string, query: string, ident: u32) -> s32
+request-get-field: function(field-type: field-type, key: string, ident: u32) -> s32
+request-set-field: function(field-type: field-type, key: string, value: list<u8>, ident: u32) -> s32
+resp-set-header: function(key: string, value: string, ident: u32)
+get-ffi-result: function(ptr: u32, ident: u32) -> s32
+add-ffi-var: function(name: string, val: string, ident: u32) -> s32
+return-abort: function(msg: string, file: string, line-num: u32, col-num: u32, ident: u32)


### PR DESCRIPTION
Bindings for JS/TS are currently auto-generated by an earlier version of [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen), the result of which is included in this repo at [`typescript/src/bindings`](/suborbital/sdk/tree/main/typescript/src/bindings). This PR serves as both documentation and initial reproduction of the process for generating these bindings from a `wit` file.

The [`wit` interface](/suborbital/sdk/blob/8254bb21d3329ff86059c68e38d8e259d84f28bd/bindings/env.wit) is derived from @ospencer's [original PR](https://github.com/suborbital/reactr/pull/203), removing the APIs that have been deprecated since.

Note that generating the JS bindings uses an older, specific version of `wit-bindgen` and JS binding generation has been removed in later versions, this PR and `wit` interface could serve as a basis of bringing this feature up-to-date with the [WebAssembly Component Model](https://github.com/WebAssembly/component-model) and modern versions of `wit-bindgen`.

Please also note, that albeit the Dockerfile will generate the Rust bindings, as provided by this version of wit-bindgen, the current SDK [uses manually written Rust language bindings](/suborbital/sdk/tree/main/rust/core/src), not auto-generated ones.